### PR TITLE
Fix some things with the bot

### DIFF
--- a/addons/assistance.py
+++ b/addons/assistance.py
@@ -17,7 +17,7 @@ class Assistance:
 
     @commands.command(pass_context=True, name="sr", hidden=True)
     async def staffreq(self, ctx, *, msg_request=""):
-        """Request staff, with optional additional text. Helpers, Staff, Verified only."""
+        """Request staff, with optional additional text. Staff only."""
         author = ctx.message.author
         if (self.bot.helpers_role not in author.roles) and (self.bot.staff_role not in author.roles) and (self.bot.verified_role not in author.roles) and (self.bot.trusted_role not in author.roles):
             msg = "{0} You cannot used this command at this time. Please ask individual staff members if you need help.".format(author.mention)
@@ -40,22 +40,22 @@ class Assistance:
         if console == "vita" or (console == "auto" and "wiiu" not in ctx.message.channel.name):
             embed = discord.Embed(title="Guide", color=discord.Color(0xCE181E))
             embed.set_author(name="Yifan Lu", url="https://henkaku.xyz/")
-            embed.set_thumbnail(url="https://pbs.twimg.com/profile_images/78071163/icon.png")
-            embed.url = "https://henkaku.xyz/"
-            embed.description = "Henkaku's main site."
+            embed.set_thumbnail(url="https://pbs.twimg.com/profile_images/698944593715310592/wTDlD5rA_400x400.png")
+            embed.url = "https://vita.hacks.guide/"
+            embed.description = "Plailect's guide for hacking your PS Vita or PSTV."
             await self.bot.say("", embed=embed)
 
 
     @commands.command()
     async def update(self):
         """Explains to not update"""
-        await self.simple_embed("Do **not** update past 3.60 or you will not be able to use henkaku!")
+        await self.simple_embed("Updating to the latest system firmware may potentially cause your console to become unhackable in the future. Spoofing the latest firmware in HENkaku Settings is recommended to avoid accidental updates.")
 
 
     @commands.command()
     async def downgrade(self):
         """Downgrade help"""
-        await self.simple_embed("You cannot currently downgrade.", title="Can I downgrade?")
+        await self.simple_embed("You can downgrade as long as your system is currently hacked. However, you can't downgrade past the firmware your console came on from the factory.", title="Can I downgrade?")
 
     @commands.command()
     async def question(self):

--- a/addons/events.py
+++ b/addons/events.py
@@ -46,10 +46,11 @@ class Events:
         'thr£eshop',
         'thr33shop',
         'fr33sh0p',
-#        'freshop',
+        'freshop',
         'fresh0p',
         'fr$shop',
-        #'pkgi',
+        'pkgi',
+        'pkgj',
         'npsbrowser',
         'nopaystation',
     ]

--- a/addons/extras.py
+++ b/addons/extras.py
@@ -20,11 +20,11 @@ class Extras:
     @commands.command()
     async def kurisu(self):
         """About Kurisu"""
-        embed = discord.Embed(title="Kurisu", color=discord.Color.green())
+        embed = discord.Embed(title="Kurisu-Vita", color=discord.Color.green())
         embed.set_author(name="916253 and ihaveahax")
-        embed.set_thumbnail(url="http://i.imgur.com/hjVY4Et.jpg")
-        embed.url = "https://github.com/916253/Kurisu"
-        embed.description = "Kurisu, the Nintendo Homebrew Discord bot!"
+        embed.set_thumbnail(url="https://github.com/ihaveamac/Kurisu-Vita/blob/master/bot-icon.png")
+        embed.url = "https://github.com/ihaveamac/Kurisu-Vita"
+        embed.description = "Kurisu-Vita, the Vita Hacking Discord bot!"
         await self.bot.say("", embed=embed)
 
     @commands.command()

--- a/run.py
+++ b/run.py
@@ -5,7 +5,7 @@
 # https://github.com/916253/Kurisu
 
 description = """
-Kurisu, the bot for the 3DS Hacking Discord!
+Kurisu, the bot for the Vita Hacking Discord!
 """
 
 # import dependencies


### PR DESCRIPTION
In a few sections, the bot acted like it was normal Kurisu rather than its own fork. Some commands in assistance.py were also flat-out wrong, like .downgrade and .update. .guide also needed a replacement, as it was only for 3.60 while vita.hacks.guide goes up to 3.70. Finally, the piracy filter was fixed to include the 2 piracy tools people keep asking for help with as well as uncommenting out another one (although nobody here should be talking about that one anyways).